### PR TITLE
current time is not assigned at very first time

### DIFF
--- a/Versions/dRehmFlight_Teensy_BETA_1.3/dRehmFlight_Teensy_BETA_1.3.ino
+++ b/Versions/dRehmFlight_Teensy_BETA_1.3/dRehmFlight_Teensy_BETA_1.3.ino
@@ -377,6 +377,7 @@ void setup() {
 
   //If using MPU9250 IMU, uncomment for one-time magnetometer calibration (may need to repeat for new locations)
   //calibrateMagnetometer(); //Generates magentometer error and scale factors to be pasted in user-specified variables section
+  current_time = micros();      
 
 }
 


### PR DESCRIPTION
Thus, when `loop()` is invoked for the first time, the `dt` will be an unexpected value.

I just put a `current_time = micros();` to the setup function.